### PR TITLE
Adjusting default successfulJobsHistoryLimit to 0 for cronjobs

### DIFF
--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.20
+version: 0.0.21
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -13,7 +13,7 @@ cronjob:
   concurrencyPolicy: "Allow"
   failedJobsHistoryLimit: 1
   schedule: "* * * * *"
-  successfulJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 0
   suspend: false
   job:
     activeDeadlineSeconds: 900 # 15 minutes
@@ -28,7 +28,7 @@ extraCronjobs:
 #   concurrencyPolicy: "Allow"
 #   failedJobsHistoryLimit: 1
 #   schedule: "* * * * *"
-#   successfulJobsHistoryLimit: 3
+#   successfulJobsHistoryLimit: 0
 #   suspend: false
 
 ##

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -44,7 +44,7 @@ cronjob:
   concurrencyPolicy: "Allow"
   failedJobsHistoryLimit: 1
   schedule: "* * * * *"
-  successfulJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 0
   suspend: false
   #   command:
   #   - /bin/sh

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.9
+version: 0.0.10
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -72,25 +72,8 @@ extraIngresses: []
 #     - chart-example.local
 
 ##
-## Cronjob
+## Cronjobs
 ##
-
-# Only for the defaults
-cronjob:
-  enabled: true
-  concurrencyPolicy: "Allow"
-  failedJobsHistoryLimit: 1
-  schedule: "* * * * *"
-  successfulJobsHistoryLimit: 3
-  suspend: false
-  job:
-    activeDeadlineSeconds: 900 # 15 minutes
-    backoffLimit: 2
-
-  #   command:
-  #   - /bin/sh
-  #   - -c
-  #   - date; echo Hello from the Kubernetes cluster
 
 cronjobs:
   []
@@ -102,7 +85,7 @@ cronjobs:
   #   concurrencyPolicy: "Allow"
   #   failedJobsHistoryLimit: 1
   #   schedule: "* * * * *"
-  #   successfulJobsHistoryLimit: 3
+  #   successfulJobsHistoryLimit: 0
   #   suspend: false
 
 ##


### PR DESCRIPTION
setting defaults for successful cronjobs to 0. removed deprecated cronjob config from monolith