### PR TITLE
fix: add component selectors

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.6
+version: 1.0.7
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_configmap.tpl
+++ b/parcellab/common/templates/_configmap.tpl
@@ -10,17 +10,15 @@
 */}}
 {{- define "common.configmap" -}}
 {{- if or .Values.config .config }}
+{{- $componentValues := (merge (deepCopy .) (dict "component" .name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 {{- $config := default .Values.config .config -}}
-{{- $fullname := include "common.fullname" . -}}
-{{- if .name -}}
-{{- $fullname = printf "%s-%s" $fullname .name -}}
-{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 data:
   {{- include "common.dictdata" (dict "data" $config) | indent 2 }}
 {{- end }}

--- a/parcellab/common/templates/_cronjob.tpl
+++ b/parcellab/common/templates/_cronjob.tpl
@@ -13,16 +13,14 @@
 {{- $_ := set $cronjob "job" dict -}}
 {{- end -}}
 {{- if or .Values.cronjob.enabled $cronjob.enabled -}}
-{{- $fullname := include "common.fullname" . -}}
-{{- if $cronjob.name -}}
-{{- $fullname = printf "%s-%s" $fullname $cronjob.name -}}
-{{- end -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $cronjob.name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
   concurrencyPolicy: {{ default .Values.cronjob.concurrencyPolicy $cronjob.concurrencyPolicy }}
   failedJobsHistoryLimit: {{ default .Values.cronjob.failedJobsHistoryLimit $cronjob.failedJobsHistoryLimit }}

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -10,6 +10,7 @@
 */}}
 {{- define "common.deployment" -}}
 {{- $service := default dict .service -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
 {{- $autoscalingEnabled := false -}}
 {{- if .Values.autoscaling -}}
 {{- $autoscalingEnabled = .Values.autoscaling.enabled -}}
@@ -17,24 +18,21 @@
 {{- if $service.autoscaling -}}
 {{- $autoscalingEnabled = $service.autoscaling.enabled -}}
 {{- end -}}
-{{- $fullname := include "common.fullname" . -}}
-{{- if $service.name -}}
-{{- $fullname = printf "%s-%s" $fullname $service.name -}}
-{{- end -}}
+{{- $name := include "common.componentname" $componentValues -}}
 {{- $type := default "service" .type -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
   {{- if not $autoscalingEnabled }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "common.selectors" . | nindent 6 }}
+      {{- include "common.selectors" $componentValues | nindent 6 }}
   template:
     {{- include "common.pod"
       (merge (deepCopy .) (dict "pod" $service "type" $type)) | nindent 4

--- a/parcellab/common/templates/_externalsecret.tpl
+++ b/parcellab/common/templates/_externalsecret.tpl
@@ -10,11 +10,9 @@
 */}}
 {{- define "common.externalsecret" -}}
 {{- if or .Values.externalSecret .externalSecret }}
-{{- $fullname := include "common.fullname" . -}}
-{{- if .name -}}
-{{- $fullname = printf "%s-%s" $fullname .name -}}
-{{- end -}}
-{{- $targetSpec := dict "creationPolicy" "Owner" "deletionPolicy" "Retain" "name" $fullname -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" .name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
+{{- $targetSpec := dict "creationPolicy" "Owner" "deletionPolicy" "Retain" "name" $name -}}
 {{- $secretStoreRefSpec := dict "name" "secretsmanager" "kind" "ClusterSecretStore" -}}
 {{- $externalSecret := mergeOverwrite
   (dict "target" $targetSpec "secretStoreRef" $secretStoreRefSpec)
@@ -23,9 +21,9 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
   {{- toYaml $externalSecret | nindent 2 }}
 {{- end }}

--- a/parcellab/common/templates/_ingress.tpl
+++ b/parcellab/common/templates/_ingress.tpl
@@ -10,16 +10,17 @@
 {{- define "common.ingress" -}}
 {{- $ingress := default (dict "enabled" false) .ingress -}}
 {{- if or .Values.ingress.enabled $ingress.enabled -}}
-{{- $fullname := default (include "common.fullname" .) $ingress.name -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $ingress.name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 {{- $tls := default .Values.ingress.tls $ingress.tls -}}
-{{- $serviceName := default $fullname $ingress.serviceName -}}
+{{- $serviceName := default $name $ingress.serviceName -}}
 {{- $servicePort := default .Values.service.port $ingress.servicePort -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
   {{- with default .Values.ingress.annotations $ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/parcellab/common/templates/_job.tpl
+++ b/parcellab/common/templates/_job.tpl
@@ -1,18 +1,16 @@
 {{- define "common.job" -}}
 {{- $job := default (dict "enabled" false) .job -}}
 {{- if or .Values.job.enabled $job.enabled -}}
-{{- $fullname := include "common.fullname" . -}}
-{{- if $job.name -}}
-{{- $fullname = printf "%s-%s" $fullname $job.name -}}
-{{- end -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $job.name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: {{ $fullname }}-
+  generateName: {{ $name }}-
   annotations:
     argocd.argoproj.io/hook: {{ default "Skip" $job.hook }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
   activeDeadlineSeconds: {{ default .Values.job.activeDeadlineSeconds $job.activeDeadlineSeconds }}
   backoffLimit: {{ default .Values.job.backoffLimit $job.backoffLimit }}

--- a/parcellab/common/templates/_labels.tpl
+++ b/parcellab/common/templates/_labels.tpl
@@ -6,10 +6,14 @@ Labels to use as selectors
       "Chart" "the chart scope"
       "Release" "the release scope"
       "Values" "the chart values scope"
+      "component" "the component of the app /optional (defaults to empty)"
   ) }}
 */}}
 {{- define "common.selectors" -}}
 {{ include "common.parcellabtagsdomain" . }}/app: {{ include "common.fullname" . | quote }}
+{{- if .component }}
+{{ include "common.parcellabtagsdomain" . }}/component: {{ .component | quote }}
+{{- end }}
 {{ include "common.parcellabtagsdomain" . }}/env: {{ include "common.env" . | quote }}
 {{- end -}}
 
@@ -20,6 +24,7 @@ Common labels
       "Chart" "the chart scope"
       "Release" "the release scope"
       "Values" "the chart values scope"
+      "component" "the component of the app /optional (defaults to empty)"
   ) }}
 */}}
 {{- define "common.labels" -}}

--- a/parcellab/common/templates/_names.tpl
+++ b/parcellab/common/templates/_names.tpl
@@ -63,6 +63,24 @@
 {{- end -}}
 
 {{/*
+  Create a component name out of the global fullname if applicable.
+  This name is used to differentiate the same application with different entry points.
+  {{ include "common.componentname" (
+    dict
+      "Release" "The Release scope"
+      "Values" "The Values scope",
+      "component" "the component of the app /optional (defaults to empty)"
+  ) }}
+*/}}
+{{- define "common.componentname" -}}
+{{- if .component -}}
+{{- printf "%s-%s" (include "common.fullname" .) .component -}}
+{{- else -}}
+{{- include "common.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
   {{ include "common.serviceAccountName" (
     dict

--- a/parcellab/common/templates/_service.tpl
+++ b/parcellab/common/templates/_service.tpl
@@ -11,13 +11,14 @@
 */}}
 {{- define "common.service" -}}
 {{- $service := default (dict) .service -}}
-{{- $fullname := default (include "common.fullname" .) $service.name -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullname }}
+  name: {{ $name }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
   type: {{ default .Values.service.type $service.serviceType }}
   ports:
@@ -26,7 +27,7 @@ spec:
       protocol: {{ default .Values.service.protocol $service.portProtocol }}
       name: {{ default .Values.service.name $service.portName }}
   selector:
-    {{- include "common.selectors" . | nindent 4 }}
+    {{- include "common.selectors" $componentValues | nindent 4 }}
     {{- if $service.extraSelectors }}
     {{- toYaml $service.extraSelectors | nindent 4 }}
     {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.23
+version: 0.0.24
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.15
+version: 0.0.16
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/service.yaml
+++ b/parcellab/monolith/templates/service.yaml
@@ -4,6 +4,5 @@
 {{- include "common.service" (merge (deepCopy $root) (dict "service" .)) }}
 ---
 {{- end }}
-{{- else }}
-{{- include "common.service" . }}
 {{- end }}
+{{- include "common.service" . }}

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.15
+version: 0.0.16
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
When having complex deployments with multiple components (e.g. a monolith application with different entry points), there is no way currently to differentiate selectors, making impossible to have multiple services.

This PR

- Fixes a bug in which the default service in the `monolith` chart would not be created if an extraService is given
- Defines a new `component` label to be use as selector when multiple resources are defined in a single chart