### PR TITLE
fix: adding single cronjob template for microservice and monolith

### DIFF
--- a/parcellab/microservice/templates/cronjob.yaml
+++ b/parcellab/microservice/templates/cronjob.yaml
@@ -1,0 +1,1 @@
+{{- include "common.cronjob" . }}

--- a/parcellab/monolith/templates/cronjob.yaml
+++ b/parcellab/monolith/templates/cronjob.yaml
@@ -1,0 +1,1 @@
+{{- include "common.cronjob" . }}


### PR DESCRIPTION
Bug: single cronjob element not. contemplated in in microservice and monolith charts

Adding single cronjob template for microservice and monolith