### PR TITLE
fix: enable cronjobs only when name is present in monolith

### DIFF
--- a/parcellab/monolith/templates/cronjobs.yaml
+++ b/parcellab/monolith/templates/cronjobs.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.cronjobs -}}
 {{- $root := . -}}
 {{- range .Values.cronjobs }}
+{{- if .name -}}
 {{- include "common.cronjob" (merge (deepCopy $root) (dict "cronjob" .)) }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
In order to fix the bug that cronjobs default to [ ] and merging with template context with enabled: true we need to ensure cronjobs only get created when they have the name attribute set in the monolith chart