### PR TITLE
fix: updated version of monolith to 0.0.21 removed obsolete cronjob.yaml

### DIFF
--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.20
+version: 0.0.21
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/cronjob.yaml
+++ b/parcellab/monolith/templates/cronjob.yaml
@@ -1,1 +1,0 @@
-{{- include "common.cronjob" . }}

--- a/parcellab/monolith/templates/cronjobs.yaml
+++ b/parcellab/monolith/templates/cronjobs.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.cronjobs -}}
+{{- if or .Values.cronjobs .cronjobs -}}
 {{- $root := . -}}
 {{- range .Values.cronjobs }}
-{{- if .name -}}
+{{- if hasKey . "name" -}}
 {{- include "common.cronjob" (merge (deepCopy $root) (dict "cronjob" .)) }}
 ---
 {{- end }}


### PR DESCRIPTION
template because just used for template values for each job defined in cronjobs attribute
