### PR TITLE
feat: adding default provisioner for nodeSelector in charts

### DIFF
--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -61,7 +61,9 @@ datadog:
 imagePullSecrets:
   - name: github-docker
 
-nodeSelector: {}
+nodeSelector:
+  type: karpenter
+  provisioner: default
 
 podAnnotations: {}
 

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -100,7 +100,9 @@ datadog:
 imagePullSecrets:
   - name: github-docker
 
-nodeSelector: {}
+nodeSelector:
+  type: karpenter
+  provisioner: default
 
 securityContext:
   {}

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -200,7 +200,9 @@ datadog:
 imagePullSecrets:
   - name: github-docker
 
-nodeSelector: {}
+nodeSelector:
+  type: karpenter
+  provisioner: default
 
 securityContext:
   {}

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -53,7 +53,9 @@ datadog:
 imagePullSecrets:
   - name: github-docker
 
-nodeSelector: {}
+nodeSelector:
+  type: karpenter
+  provisioner: default
 
 securityContext:
   {}


### PR DESCRIPTION
We need to introduce a default node selector for services that require “no specialties”, meaning the can be run on every node (on demand nodes as well as spot nodes) and don’t have specific requirements for e.g. networking. This should be then the default node selector passed through the charts or set if not specified.

https://parcellab.atlassian.net/browse/INF-500