### PR TITLE
feat: adding strategy in deployment

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.13
+version: 1.0.14
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -30,6 +30,10 @@ spec:
   {{- if not $autoscalingEnabled }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
   {{- end }}
+  {{- with default .Values.strategy .deployment.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "common.selectors" $componentValues | nindent 6 }}

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -28,6 +28,7 @@ podDisruptionBudget:
     maxUnavailable: "50%"
 podSecurityContext: {}
 replicaCount: 1
+strategy: {}
 resources: {}
 securityContext: {}
 serviceAccount:

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.19
+version: 0.0.20
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -125,6 +125,8 @@ podAnnotations: {}
 
 replicaCount: 1
 
+strategy: {}
+
 tolerations: []
 
 volumes: []

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -125,7 +125,10 @@ podAnnotations: {}
 
 replicaCount: 1
 
-strategy: {}
+strategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 
 tolerations: []
 

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.26
+version: 0.0.27
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -225,6 +225,8 @@ podAnnotations: {}
 
 replicaCount: 1
 
+strategy: {}
+
 tolerations: []
 
 volumes: []

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -225,7 +225,10 @@ podAnnotations: {}
 
 replicaCount: 1
 
-strategy: {}
+strategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 
 tolerations: []
 

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.23
+version: 0.0.24
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -78,6 +78,8 @@ podAnnotations: {}
 
 replicaCount: 1
 
+strategy: {}
+
 tolerations: []
 
 volumes: []

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -78,7 +78,10 @@ podAnnotations: {}
 
 replicaCount: 1
 
-strategy: {}
+strategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 
 tolerations: []
 


### PR DESCRIPTION
In order to avoid downtime during deployments we are going to add strategies for rolling updates.

https://www.cncf.io/wp-content/uploads/2020/08/CNCF-Presentation-Template-K8s-Deployment.pdf