### PR TITLE
fix: rolling back versions for postgresql chart and redis chart

### DIFF
--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -8,9 +8,9 @@ dependencies:
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.6.3
+    version: 12.5.6
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.11.7
+    version: 17.11.3
     condition: redis.enabled

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -8,9 +8,9 @@ dependencies:
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.6.3
+    version: 12.5.6
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.11.7
+    version: 17.11.3
     condition: redis.enabled

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -8,9 +8,9 @@ dependencies:
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.6.3
+    version: 12.5.6
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.11.7
+    version: 17.11.3
     condition: redis.enabled


### PR DESCRIPTION
dbt started to fail in prod due to the upgrade. Rolling back changes.

![image](https://github.com/parcelLab/charts/assets/17253484/52434474-bc27-4984-a09c-ba668715c520)
