### PR TITLE
feat: adding autoscaling for extra services in monolith

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.17
+version: 1.0.18
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -11,7 +11,6 @@
 {{- define "common.deployment" -}}
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
-{{- $autoscalingEnabled := false -}}
 {{- $name := include "common.componentname" $componentValues -}}
 {{- $type := default "service" .type -}}
 apiVersion: apps/v1

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -12,12 +12,6 @@
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
 {{- $autoscalingEnabled := false -}}
-{{- if .Values.autoscaling -}}
-{{- $autoscalingEnabled = .Values.autoscaling.enabled -}}
-{{- end -}}
-{{- if $service.autoscaling -}}
-{{- $autoscalingEnabled = $service.autoscaling.enabled -}}
-{{- end -}}
 {{- $name := include "common.componentname" $componentValues -}}
 {{- $type := default "service" .type -}}
 apiVersion: apps/v1
@@ -27,9 +21,7 @@ metadata:
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
-  {{- if not $autoscalingEnabled }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
-  {{- end }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/parcellab/common/templates/_hpa.tpl
+++ b/parcellab/common/templates/_hpa.tpl
@@ -27,7 +27,7 @@ spec:
     kind: Deployment
     name: {{ $fullname }}
   minReplicas: {{ default .Values.autoscaling.minReplicas $autoscaling.minReplicas }}
-  maxReplicas: {{ default .Values.autoscaling.maxReplicas $autoscaling.minReplicas }}
+  maxReplicas: {{ default .Values.autoscaling.maxReplicas $autoscaling.maxReplicas }}
   metrics:
     {{- if $targetCPUUtilizationPercentage }}
     - type: Resource

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.31
+version: 0.0.32
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/hpa-services.yaml
+++ b/parcellab/monolith/templates/hpa-services.yaml
@@ -1,0 +1,9 @@
+{{- $root := . -}}
+{{- if .Values.extraServices -}}
+{{- range .Values.extraServices }}
+{{- if .autoscaling -}}
+{{- include "common.hpa" (merge (deepCopy $root) (dict "autoscaling" .autoscaling "name" .name)) }}
+{{- end }}
+---
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
https://parcellab.atlassian.net/browse/INF-1017

Adding template to use autoscaling(HPA) for extra services.

Fixing logic to use replicaCounts with extra services. If you enable HPA even if you settle replicaCount the autoscaling config prevails over the replicaCount anyway by default.

Fixing typo in common hpa template.