### PR TITLE
feat: updating parcellab charts with latest common templates

### DIFF
--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.33
+version: 0.0.34
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.23
+version: 0.0.24
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.27
+version: 0.0.28
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
Forgot to update some charts versions to use latest common templates.
