### PR TITLE
feat: removing default value for readOnly parameter in volumes

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.18
+version: 1.0.19
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_container.tpl
+++ b/parcellab/common/templates/_container.tpl
@@ -51,7 +51,7 @@ volumeMounts:
   {{- if .volumes }}
   {{- range .volumes }}
   - name: {{ .name }}
-    readOnly: {{ default true .readOnly }}
+    readOnly: {{ .readOnly }}
     mountPath: {{ .mountPath }}
   {{- end }}
   {{- end }}

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -115,7 +115,7 @@ spec:
         {{- if $podVolumes }}
         {{- range $podVolumes }}
         - name: {{ .name }}
-          readOnly: {{ default true .readOnly }}
+          readOnly: {{ .readOnly }}
           mountPath: {{ .mountPath }}
         {{- end }}
         {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.34
+version: 0.0.35
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.24
+version: 0.0.25
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.33
+version: 0.0.34
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.28
+version: 0.0.29
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
For some reason, the default value is always used even if you settle the `readOnly: false` in the `values.yaml`