### PR TITLE
fix: remove job history limit / use TTL

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.21
+version: 1.0.22
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_job.tpl
+++ b/parcellab/common/templates/_job.tpl
@@ -15,6 +15,7 @@ metadata:
 spec:
   activeDeadlineSeconds: {{ default .Values.job.activeDeadlineSeconds $job.activeDeadlineSeconds }}
   backoffLimit: {{ default .Values.job.backoffLimit $job.backoffLimit }}
+  ttlSecondsAfterFinished: {{ default .Values.job.ttlSecondsAfterFinished $job.ttlSecondsAfterFinished }}
 
   template:
     {{- include "common.pod"

--- a/parcellab/common/templates/_job.tpl
+++ b/parcellab/common/templates/_job.tpl
@@ -15,8 +15,6 @@ metadata:
 spec:
   activeDeadlineSeconds: {{ default .Values.job.activeDeadlineSeconds $job.activeDeadlineSeconds }}
   backoffLimit: {{ default .Values.job.backoffLimit $job.backoffLimit }}
-  failedJobsHistoryLimit: {{ default .Values.job.failedJobsHistoryLimit $job.failedJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ default .Values.job.successfulJobsHistoryLimit $job.successfulJobsHistoryLimit }}
 
   template:
     {{- include "common.pod"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.36
+version: 0.0.37
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -104,6 +104,7 @@ job:
   backoffLimit: 1
   activeDeadlineSeconds: 300
   restartPolicy: Never
+  ttlSecondsAfterFinished: 3600
 
 jobs: []
 #  - name: migrate

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -104,8 +104,6 @@ job:
   backoffLimit: 1
   activeDeadlineSeconds: 300
   restartPolicy: Never
-  failedJobsHistoryLimit: 2
-  successfulJobsHistoryLimit: 1
 
 jobs: []
 #  - name: migrate


### PR DESCRIPTION
there was a reason why it was not included, it does not work on jobs, only cronjobs, apparently TTL is the proper settings for jobs.
