### PR TITLE
fix: remove replicacount default value

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.21
+version: 1.0.22
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -27,7 +27,7 @@ podDisruptionBudget:
   spec:
     maxUnavailable: "50%"
 podSecurityContext: {}
-replicaCount: 1
+# replicaCount: 1 # think we need to remove this
 strategy: {}
 resources: {}
 securityContext: {}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.36
+version: 0.0.37
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.26
+version: 0.0.27
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -122,7 +122,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 
 strategy:
   rollingUpdate:

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -225,7 +225,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 
 strategy:
   rollingUpdate:

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.30
+version: 0.0.31
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -75,7 +75,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 
 strategy:
   rollingUpdate:


### PR DESCRIPTION
I believe we must remove the replica count default value.
Otherwise - if no value is defined - it is set to '1' instead of leaving the scaler to manage it.
