### PR TITLE
chore: enabling worker deploys with no replicas

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.22
+version: 1.0.23
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -20,7 +20,7 @@ metadata:
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
-  {{- if .Values.replicaCount }}
+  {{- if not (eq $service.disableReplicas true) }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
   {{- end }}
   {{- with .Values.strategy }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.36
+version: 0.0.37
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.26
+version: 0.0.27
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.30
+version: 0.0.31
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
## Description

Adding `disableReplicas: false` to the worker definition, we can create deploys with no workers, so the scaler can manage them.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
