### PR TITLE
fix: remove replicacount default value

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.24
+version: 1.0.25
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -27,7 +27,7 @@ podDisruptionBudget:
   spec:
     maxUnavailable: "50%"
 podSecurityContext: {}
-replicaCount: 1
+# replicaCount: 1 # think we need to remove this
 revisionHistoryLimit: 0
 strategy: {}
 resources: {}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.38
+version: 0.0.39
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.28
+version: 0.0.29
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -124,7 +124,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 
 strategy:
   rollingUpdate:

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.39
+version: 0.0.40
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -227,7 +227,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 
 strategy:
   rollingUpdate:

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.32
+version: 0.0.33
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -77,7 +77,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-replicaCount: 1
+# replicaCount: 1
 disableReplicas: false
 
 strategy:


### PR DESCRIPTION
I believe we must remove the replica count default value.
Otherwise - if no value is defined - it is set to '1' instead of leaving the scaler to manage it.
