### PR TITLE
chore: enable disabling of replica count on primary service for autoscaling

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.24
+version: 1.0.25
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -12,6 +12,7 @@
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
 {{- $name := include "common.componentname" $componentValues -}}
+{{- $disableReplicas := default .Values.disableReplicas $service.disableReplicas -}}
 {{- $type := default "service" .type -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -20,7 +21,7 @@ metadata:
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
-  {{- if not (eq $service.disableReplicas true) }}
+  {{- if not (eq $disableReplicas true) }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
   {{- end }}
   {{- with .Values.strategy }}

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -12,7 +12,7 @@
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
 {{- $name := include "common.componentname" $componentValues -}}
-{{- $disableReplicas := default .Values.disableReplicas $service.disableReplicas -}}
+{{- $disableReplicaCount := default .Values.disableReplicaCount $service.disableReplicaCount -}}
 {{- $type := default "service" .type -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -21,7 +21,7 @@ metadata:
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
-  {{- if not (eq $disableReplicas true) }}
+  {{- if not (eq $disableReplicaCount true) }}
   replicas: {{ default .Values.replicaCount $service.replicaCount }}
   {{- end }}
   {{- with .Values.strategy }}

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -1,5 +1,6 @@
 # Default values (to be defined in the caller chart based on the resources they use)
 affinity: {}
+disableReplicas: false
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -1,6 +1,6 @@
 # Default values (to be defined in the caller chart based on the resources they use)
 affinity: {}
-disableReplicas: false
+disableReplicaCount: false
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.28
+version: 0.0.29
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.39
+version: 0.0.40
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -228,6 +228,8 @@ serviceAccount:
 podAnnotations: {}
 
 replicaCount: 1
+# disables setting replica count in case of autoscaling enabled
+disableReplicas: false
 
 strategy:
   rollingUpdate:

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -154,7 +154,7 @@ workers:
   #   containerEnv:
   #     - name: MY_ENV_VAR
   #       value: "myvalue"
-  #   disableReplicas: false
+  #   disableReplicaCount: false
 
 ##
 ## Configuration
@@ -229,7 +229,7 @@ podAnnotations: {}
 
 replicaCount: 1
 # disables setting replica count in case of autoscaling enabled
-disableReplicas: false
+disableReplicaCount: false
 
 strategy:
   rollingUpdate:

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.32
+version: 0.0.33
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -78,7 +78,7 @@ serviceAccount:
 podAnnotations: {}
 
 replicaCount: 1
-disableReplicas: false
+disableReplicaCount: false
 
 strategy:
   rollingUpdate:


### PR DESCRIPTION
& rename `disableReplicas` to `disableReplicaCount`, due to ambigous naming