### PR TITLE
chore: create keda scaling from workers definition

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.26
+version: 1.0.27
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_keda.tpl
+++ b/parcellab/common/templates/_keda.tpl
@@ -18,25 +18,25 @@ metadata:
     scaledobject.keda.sh/transfer-hpa-ownership: 'true'
     autoscaling.keda.sh/paused-replicas: "0"
     autoscaling.keda.sh/paused: "{{ $service.keda.paused }}"
-
   labels:
     argocd.argoproj.io/instance: keda
   name: {{/* */}}-{{ $name }}-keda-scale
   namespace: {{/* */}}
+
 spec:
   advanced:
     restoreToOriginalReplicaCount: {{ $service.keda.restoreToOriginalReplicaCount }}
-  cooldownPeriod: {{ $service.cooldownPeriod }}
-  maxReplicaCount: {{ $service.maxReplicaCount }}
-  minReplicaCount: {{ $service.minReplicaCount }}
-  pollingInterval: {{ $service.pollingInterval }}
+  cooldownPeriod: {{ $service.keda.cooldownPeriod }}
+  maxReplicaCount: {{ $service.keda.maxReplicaCount }}
+  minReplicaCount: {{ $service.keda.minReplicaCount }}
+  pollingInterval: {{ $service.keda.pollingInterval }}
   scaleTargetRef:
-    name: {{ $service.scaleTargetName }}
+    name: {{ $service.keda.scaleTargetName }}
   triggers:
     - metadata:
-        awsRegion: {{ $service.awsRegion }}
-        queueLength: {{ $service.queueLength }}
-        queueURL: {{ $service.queueURL }}
+        awsRegion: "{{ $service.keda.awsRegion }}"
+        queueLength: "{{ $service.keda.queueLength }}"
+        queueURL: {{ $service.keda.queueURL }}
         identityOwner: pod
       type: aws-sqs-queue
       authenticationRef:

--- a/parcellab/common/templates/_keda.tpl
+++ b/parcellab/common/templates/_keda.tpl
@@ -20,8 +20,8 @@ metadata:
     autoscaling.keda.sh/paused: "{{ $service.keda.paused }}"
   labels:
     argocd.argoproj.io/instance: keda
-  name: {{/* */}}-{{ $name }}-keda-scale
-  namespace: {{/* */}}
+  name: {{ .Release.Namespace }}-{{ $name }}-keda-scale
+  namespace: {{ .Release.Namespace }}
 
 spec:
   advanced:

--- a/parcellab/common/templates/_keda.tpl
+++ b/parcellab/common/templates/_keda.tpl
@@ -8,33 +8,35 @@
   ) }}
 */}}
 {{- define "keda.hpa" -}}
-{{- $keda := default dict . -}}
+{{- $service := default dict .service -}}
+{{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
+{{- $name := include "common.componentname" $componentValues -}}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   annotations:
     scaledobject.keda.sh/transfer-hpa-ownership: 'true'
     autoscaling.keda.sh/paused-replicas: "0"
-    autoscaling.keda.sh/paused: "{{ .keda.paused }}"
+    autoscaling.keda.sh/paused: "{{ $service.keda.paused }}"
 
   labels:
     argocd.argoproj.io/instance: keda
-  name: {{ .Release.Namespace }}-{{ .Values }}-keda-scale
-  namespace: {{ .Release.Namespace }}
+  name: {{/* */}}-{{ $name }}-keda-scale
+  namespace: {{/* */}}
 spec:
   advanced:
-    restoreToOriginalReplicaCount: {{ .keda.restoreToOriginalReplicaCount }}
-  cooldownPeriod: {{ .keda.cooldownPeriod }}
-  maxReplicaCount: {{ .keda.maxReplicaCount }}
-  minReplicaCount: {{ .keda.minReplicaCount }}
-  pollingInterval: {{ .keda.pollingInterval }}
+    restoreToOriginalReplicaCount: {{ $service.keda.restoreToOriginalReplicaCount }}
+  cooldownPeriod: {{ $service.cooldownPeriod }}
+  maxReplicaCount: {{ $service.maxReplicaCount }}
+  minReplicaCount: {{ $service.minReplicaCount }}
+  pollingInterval: {{ $service.pollingInterval }}
   scaleTargetRef:
-    name: {{ .keda.scaleTargetName }}
+    name: {{ $service.scaleTargetName }}
   triggers:
     - metadata:
-        awsRegion: {{ .keda.awsRegion }}
-        queueLength: {{ .keda.queueLength }}
-        queueURL: {{ .keda.queueURL }}
+        awsRegion: {{ $service.awsRegion }}
+        queueLength: {{ $service.queueLength }}
+        queueURL: {{ $service.queueURL }}
         identityOwner: pod
       type: aws-sqs-queue
       authenticationRef:

--- a/parcellab/common/templates/_keda.tpl
+++ b/parcellab/common/templates/_keda.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+  Common horizontal pod autoscaler definition:
+  {{ include "keda.hpa" (
+    dict
+      "Values" "the values scope"
+      "Release" "the release scope"
+  ) }}
+*/}}
+{{- define "keda.hpa" -}}
+{{- $keda := default dict . -}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  annotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: 'true'
+    autoscaling.keda.sh/paused-replicas: "0"
+    autoscaling.keda.sh/paused: "{{ .keda.paused }}"
+
+  labels:
+    argocd.argoproj.io/instance: keda
+  name: {{ .Release.Namespace }}-{{ .Values }}-keda-scale
+  namespace: {{ .Release.Namespace }}
+spec:
+  advanced:
+    restoreToOriginalReplicaCount: {{ .keda.restoreToOriginalReplicaCount }}
+  cooldownPeriod: {{ .keda.cooldownPeriod }}
+  maxReplicaCount: {{ .keda.maxReplicaCount }}
+  minReplicaCount: {{ .keda.minReplicaCount }}
+  pollingInterval: {{ .keda.pollingInterval }}
+  scaleTargetRef:
+    name: {{ .keda.scaleTargetName }}
+  triggers:
+    - metadata:
+        awsRegion: {{ .keda.awsRegion }}
+        queueLength: {{ .keda.queueLength }}
+        queueURL: {{ .keda.queueURL }}
+        identityOwner: pod
+      type: aws-sqs-queue
+      authenticationRef:
+        name: cluster-trigger-authentication
+        kind: ClusterTriggerAuthentication
+{{- end -}}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.39
+version: 0.0.40
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.30
+version: 0.0.31
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.41
+version: 0.0.42
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/keda-workers.yaml
+++ b/parcellab/monolith/templates/keda-workers.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- if .Values.workers -}}
 {{- range .Values.workers }}
-{{- include "keda.hpa" . }}
+{{- include "keda.hpa" (merge (deepCopy $root) (dict "service" . "type" "worker")) }}
 ---
 {{- end -}}
 {{- end -}}

--- a/parcellab/monolith/templates/keda-workers.yaml
+++ b/parcellab/monolith/templates/keda-workers.yaml
@@ -1,0 +1,7 @@
+{{- $root := . -}}
+{{- if .Values.workers -}}
+{{- range .Values.workers }}
+{{- include "keda.hpa" . }}
+---
+{{- end -}}
+{{- end -}}

--- a/parcellab/monolith/templates/keda-workers.yaml
+++ b/parcellab/monolith/templates/keda-workers.yaml
@@ -1,7 +1,9 @@
 {{- $root := . -}}
 {{- if .Values.workers -}}
 {{- range .Values.workers }}
+{{- if .keda -}}
 {{- include "keda.hpa" (merge (deepCopy $root) (dict "service" . "type" "worker")) }}
 ---
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -155,6 +155,20 @@ workers:
   #     - name: MY_ENV_VAR
   #       value: "myvalue"
   #   disableReplicaCount: false
+  #
+  #   KEDA configuration is optional
+  #
+  #   keda:
+  #     paused: false
+  #     restoreToOriginalReplicaCount: true
+  #     cooldownPeriod: 300
+  #     maxReplicaCount: 2
+  #     minReplicaCount: 1
+  #     pollingInterval: 3600
+  #     scaleTargetName: NAME_OF_DEPLOYMENT
+  #     awsRegion: "AWS_REGION"
+  #     queueLength: '100'
+  #     queueURL: SQS_QUEUE
 
 ##
 ## Configuration

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.34
+version: 0.0.35
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
## Description

Now we can add a KEDA object from a worker definition. Only works with AWS SQS.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
