### PR TITLE
fix: adds datadog socket volume safe-to-evict annotation

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.37
+version: 1.0.38
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -22,6 +22,9 @@
 {{- $type := default "service" .type -}}
 metadata:
   annotations:
+    {{- if and $datadog $datadog.enabled }}
+    "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "apmsocketpath"
+    {{- end }}
   {{- with .Values.podAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.50
+version: 0.0.51
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.41
+version: 0.0.42
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.52
+version: 0.0.53
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/deployment-workers.yaml
+++ b/parcellab/monolith/templates/deployment-workers.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- if .Values.workers -}}
 {{- range .Values.workers }}
-{{- include "common.deployment" (merge (deepCopy $root) (dict "service" . "type" "worker")) }}
+{{- include "common.deployment" (merge (merge (deepCopy $root) (dict "worker" .)) (dict "service" . "type" "worker")) }}
 ---
 {{- end -}}
 {{- end -}}

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -128,6 +128,17 @@ jobs: []
 ## Workers
 ##
 
+worker:
+  # only for default values
+#  resources:
+#    limits:
+#      cpu: 100m
+#      memory: 128Mi
+#    requests:
+#      cpu: 50m
+#      memory:
+#        64Mi
+
 workers: []
 #  - name: myworker
 #    command:
@@ -148,32 +159,24 @@ workers: []
 #      httpGet:
 #        path: /
 #        port: http
-#    resources:
-#      limits:
-#        cpu: 100m
-#        memory: 128Mi
-#      requests:
-#        cpu: 50m
-#        memory: 64Mi
 #    containerEnv:
 #      - name: MY_ENV_VAR
 #        value: "myvalue"
-#    disableReplicaCount: false
 #
-#   KEDA configuration is optional
+#    # KEDA configuration is optional
 #
-#   keda:
-#     paused: false
-#     restoreToOriginalReplicaCount: true
-#     cooldownPeriod: 300
-#     maxReplicaCount: 2
-#     minReplicaCount: 1
-#     pollingInterval: 3600
-#     scaleTargetName: NAME_OF_DEPLOYMENT
-#     awsRegion: "AWS_REGION"
-#     queueLength: '100'
-#     queueURL: SQS_QUEUE
-#     scaleOnInFlight: false
+#    keda:
+#      paused: false
+#      restoreToOriginalReplicaCount: true
+#      cooldownPeriod: 300
+#      maxReplicaCount: 2
+#      minReplicaCount: 1
+#      pollingInterval: 3600
+#      scaleTargetName: NAME_OF_DEPLOYMENT
+#      awsRegion: "AWS_REGION"
+#      queueLength: "100"
+#      queueURL: SQS_QUEUE
+#      scaleOnInFlight: false
 
 ##
 ## Configuration

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.45
+version: 0.0.46
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
the cluster autoscaler seems to be at the moment not moving our pods, as they have local host mounts.

also adds worker default values

