### PR TITLE
fix: fixing hpa template with deployment names

### DIFF
--- a/parcellab/common/templates/_hpa.tpl
+++ b/parcellab/common/templates/_hpa.tpl
@@ -18,14 +18,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ $fullname }}
+  name: {{ $fullname | default (include "common.fullname" .) }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $fullname }}
+    name: {{ $fullname | default (include "common.fullname" .) }}
   minReplicas: {{ default .Values.autoscaling.minReplicas $autoscaling.minReplicas }}
   maxReplicas: {{ default .Values.autoscaling.maxReplicas $autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
https://parcellab.atlassian.net/browse/INF-1325

## Description

It seems the HPA template is not using the correct deployment name. This should fix it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
