### PR TITLE
feat: Add support for extra ports in service and pod templates

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.45
+version: 1.0.46
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -109,6 +109,13 @@ spec:
         - name: {{ default .Values.service.name .pod.portName }}
           containerPort: {{ default .Values.service.port .pod.portNumber }}
           protocol: {{ default .Values.service.protocol .pod.portProtocol }}
+        {{- if .Values.service.extraPorts }}
+        {{- range .Values.service.extraPorts }}
+        - name: {{ .name }}
+          containerPort: {{ .port }}
+          protocol: {{ default "TCP" .protocol }}
+        {{- end }}
+        {{- end }}
       {{- else }}
       {{- /* Force liveness and readiness probes to be defined if the deployment is not a service */ -}}
       {{- with .pod.livenessProbe }}

--- a/parcellab/common/templates/_rollout.tpl
+++ b/parcellab/common/templates/_rollout.tpl
@@ -99,8 +99,8 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- end }}
 {{- $previewService := mergeOverwrite $service (dict "name" (printf "%s-preview" $name) ) -}}
 {{- include "common.service" (merge (deepCopy .) (dict "service" $previewService )) }}
 ---
+{{- end }}
 {{- end }}

--- a/parcellab/common/templates/_service.tpl
+++ b/parcellab/common/templates/_service.tpl
@@ -26,6 +26,14 @@ spec:
       targetPort: {{ default .Values.service.targetPort $service.portName }}
       protocol: {{ default .Values.service.protocol $service.portProtocol }}
       name: {{ default .Values.service.name $service.portName }}
+    {{- if .Values.service.extraPorts }}
+    {{- range .Values.service.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ default "TCP" .protocol }}
+      name: {{ .name }}
+    {{- end }}
+    {{- end }}
   selector:
     {{- include "common.selectors" $componentValues | nindent 4 }}
     {{- if $service.extraSelectors }}

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -44,6 +44,15 @@ service:
   protocol: "TCP"
   targetPort: "http"
   type: "ClusterIP"
+  # extraPorts:
+  # - name: https
+  #   port: 443
+  #   targetPort: https
+  #   protocol: TCP
+  # - name: metrics
+  #   port: 9100
+  #   targetPort: metrics
+  #   protocol: TCP
 tolerations: []
 vpa:
   enabled: false

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.58
+version: 0.0.59
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.49
+version: 0.0.50
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -14,6 +14,15 @@ service:
   targetPort: http
   protocol: TCP
   type: ClusterIP
+  # extraPorts:
+  # - name: https
+  #   port: 443
+  #   targetPort: https
+  #   protocol: TCP
+  # - name: metrics
+  #   port: 9100
+  #   targetPort: metrics
+  #   protocol: TCP
 
 revisionHistoryLimit: 0
 

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.63
+version: 0.0.64
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -14,6 +14,15 @@ service:
   targetPort: http
   protocol: TCP
   type: ClusterIP
+  # extraPorts:
+  # - name: https
+  #   port: 443
+  #   targetPort: https
+  #   protocol: TCP
+  # - name: metrics
+  #   port: 9100
+  #   targetPort: metrics
+  #   protocol: TCP
 
 revisionHistoryLimit: 0
 

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.56
+version: 0.0.57
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -265,6 +265,15 @@ service:
   targetPort: http
   protocol: TCP
   type: ClusterIP
+  # extraPorts:
+  # - name: https
+  #   port: 443
+  #   targetPort: https
+  #   protocol: TCP
+  # - name: metrics
+  #   port: 9100
+  #   targetPort: metrics
+  #   protocol: TCP
 
 ##
 ## Ingress


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
This pull request introduces the ability to specify extra ports for services and pods within the Helm chart, enhancing the flexibility of service definitions.
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
The change is required to allow users to define additional ports in the pod's container spec and in the service, which is essential for services that need to expose more than the default port. This is particularly useful for applications that serve multiple protocols or require additional ports for metrics, health checks, or other purposes.

<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
The changes include:
- Modifying the `_service.tpl` template to iterate over an array of extra ports defined in `.Values.service.extraPorts`.
- Modifying the `_pod.tpl` template to iterate over an array of extra ports defined in `.Values.service.extraPorts`.
- Updating the `values.yaml` file to include an example of how to specify extra ports.
- Upgrading charts versions.
<!--- Include details of how you tested the change -->
The change was tested by:
- Deploying the Helm chart to a local Kubernetes cluster.
- Verifying that the specified extra ports were correctly exposed by the pod's containers.
- Running a service that listens on the additional ports and ensuring it's accessible.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
