### PR TITLE
fix: Fixing templates for poddisruptionbudget in worker-group chart.

### DIFF
--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.57
+version: 0.0.58
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/templates/poddisruptionbudget-workers.yaml
+++ b/parcellab/worker-group/templates/poddisruptionbudget-workers.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.workers -}}
+{{- $root := . -}}
+{{- range .Values.workers }}
+{{- if .podDisruptionBudget -}}
+{{- include "common.poddisruptionbudget" (merge (deepCopy $root) (dict "podDisruptionBudget" .podDisruptionBudget "name" .name)) }}
+---
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/parcellab/worker-group/templates/poddisruptionbudget.yaml
+++ b/parcellab/worker-group/templates/poddisruptionbudget.yaml
@@ -1,10 +1,1 @@
-{{- if .Values.workers -}}
-{{- $root := . -}}
-{{- range .Values.workers }}
-{{- if .podDisruptionBudget -}}
-{{- include "common.poddisruptionbudget" (merge (deepCopy $root) (dict "podDisruptionBudget" .podDisruptionBudget "name" .name)) }}
-{{- end -}}
----
-{{- end -}}
-{{- end -}}
 {{- include "common.poddisruptionbudget" . }}


### PR DESCRIPTION
This PR includes a fix for the PodDisruptionBudget templates in the worker-group chart.
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
Fixing poddisruptionbudget templates for worker-group chart.
<!--- Why is this change required? What problem does it solve? -->
The PodDisruptionBudget templates had an issue causing an error on deployment.

<!--- Describe your changes in detail -->
The changes include:
- Creating additional template for extra workers.

<!--- Include details of how you tested the change -->
The changes were tested by:
- Generating an example yaml file using the changes locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly