### PR TITLE
fix: Fixing metadata name for rollout template in common chart.

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.51
+version: 1.0.52
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_rollout.tpl
+++ b/parcellab/common/templates/_rollout.tpl
@@ -13,7 +13,7 @@
 {{- define "common.argorollout" -}}
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
-{{- $name := include "common.componentname" $componentValues -}}
+{{- $name := default (include "common.fullname" .) .name -}}
 {{- $disableReplicaCount := (ternary $service.disableReplicaCount .Values.disableReplicaCount (hasKey $service "disableReplicaCount")) -}}
 {{- $argoRollout := default (dict "enabled" false) .Values.argoRollout -}}
 {{- $type := default "service" .type -}}
@@ -21,7 +21,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: {{ $name }}
+  name: {{ $name | default (include "common.fullname" .) }}
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
   {{- if $argoRollout.notifications }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.64
+version: 0.0.65
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.56
+version: 0.0.57
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.68
+version: 0.0.69
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.61
+version: 0.0.62
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
Argo rollout configuration for extra services in the monolith chart was using the global deployment name instead the name of the services.
Fixing the metadata name field in rollout template in the common chart. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
<!--- Include details of how you tested the change -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
