### PR TITLE
fix: Fix YAML parsing issue in poddisruptionbudget and rollout extraservices.

### DIFF
--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.70
+version: 0.0.71
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/poddisruptionbudget-service.yaml
+++ b/parcellab/monolith/templates/poddisruptionbudget-service.yaml
@@ -3,7 +3,7 @@
 {{- range .Values.extraServices }}
 {{- if .podDisruptionBudget -}}
 {{- include "common.poddisruptionbudget" (merge (deepCopy $root) (dict "podDisruptionBudget" .podDisruptionBudget "name" .name)) }}
-{{- end -}}
+{{- end }}
 ---
 {{- end -}}
 {{- end -}}

--- a/parcellab/monolith/templates/rollout-service.yaml
+++ b/parcellab/monolith/templates/rollout-service.yaml
@@ -3,7 +3,7 @@
 {{- range .Values.extraServices }}
 {{- if .argoRollout -}}
 {{- include "common.argorollout" (merge (deepCopy $root) (dict "argoRollout" .argoRollout "name" .name)) }}
-{{- end -}}
+{{- end }}
 ---
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
When defining more than two `extraServices` in the values file, the Helm chart fails with a YAML parsing error. This is due to the incorrect placement of the YAML document separator `---` which is generated after each `podDisruptionBudget` definition, even when the `podDisruptionBudget` is not present for a service. The error message is as follows:

`Error: YAML parse error on product-api/charts/monolith/templates/poddisruptionbudget-service.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type releaseutil.SimpleHead
`

Same issues with rollout.service.yaml.

The templates have been updated by changing the `{{- end -}}` to `{{- end }}`. This prevents the generation of empty YAML documents separated by `---` when there is no `podDisruptionBudget` or  `argoRollout` defined for a extra services.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
