### PR TITLE
fix: inf-1597 Fixes the inheritance from the cronjob (default) block to cronjobs

### DIFF
--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.71
+version: 0.0.72
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/cronjobs.yaml
+++ b/parcellab/monolith/templates/cronjobs.yaml
@@ -1,8 +1,9 @@
 {{- if or .Values.cronjobs .cronjobs -}}
 {{- $root := . -}}
+{{- $defaultCronjob := .Values.cronjob}}
 {{- range .Values.cronjobs }}
 {{- if hasKey . "name" -}}
-{{- include "common.cronjob" (merge (deepCopy $root) (dict "cronjob" .)) }}
+{{- include "common.cronjob" (merge (deepCopy $root) (dict "cronjob" (mergeOverwrite (deepCopy (default dict $defaultCronjob)) .))) }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes the bug that the common values in the `cronjob` block for default values is not considered in the cronjob manifests. Currently the only the values from the top level were passed. 