### PR TITLE
feat: Adding timeZone configuration for cronjobs.

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.54
+version: 1.0.55
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_cronjob.tpl
+++ b/parcellab/common/templates/_cronjob.tpl
@@ -27,6 +27,7 @@ spec:
   schedule: {{ default .Values.cronjob.schedule $cronjob.schedule | quote }}
   successfulJobsHistoryLimit: {{ default .Values.cronjob.successfulJobsHistoryLimit $cronjob.successfulJobsHistoryLimit }}
   suspend: {{ default .Values.cronjob.suspend $cronjob.suspend }}
+  timeZone: {{ default .Values.cronjob.timeZone $cronjob.timeZone | quote }}
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ default .Values.cronjob.job.activeDeadlineSeconds $cronjob.activeDeadlineSeconds }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.67
+version: 0.0.68
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -17,6 +17,7 @@ cronjob:
   schedule: "* * * * *"
   successfulJobsHistoryLimit: 3
   suspend: false
+  timeZone: Europe/Berlin
   job:
     activeDeadlineSeconds: 900 # 15 minutes
     backoffLimit: 2

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.59
+version: 0.0.60
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -57,6 +57,7 @@ cronjob:
   schedule: "* * * * *"
   successfulJobsHistoryLimit: 3
   suspend: false
+  timeZone: Europe/Berlin
   job:
     activeDeadlineSeconds: 120
   #   command:

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.0.73
+version: 0.0.74
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -83,6 +83,7 @@ cronjob:
   schedule: "* * * * *"
   successfulJobsHistoryLimit: 3
   suspend: false
+  timeZone: Europe/Berlin
   job:
     activeDeadlineSeconds: 900 # 15 minutes
     backoffLimit: 2

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.63
+version: 0.0.64
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
Adding the `timeZone` configuration for cronjobs in the common charts. 

Please note that the `timeZone` field is only available in Kubernetes version 1.21 and later.

https://parcellab.atlassian.net/browse/INF-1679
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
<!--- Include details of how you tested the change -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
