### PR TITLE
feat: INF-1799 Adding step in release pipeline to bump the versions f…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,19 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Bump version
+        run: |
+          for dir in parcellab/*; do
+              if [ -d "$dir" ]; then
+                  echo "Processing $dir"
+                  version=$(grep 'version:' $dir/Chart.yaml | cut -d ' ' -f 2)
+                  version_bump=$(echo "$version" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+                  sed -i "s/version: $version/version: $version_bump/g" $dir/Chart.yaml
+              fi
+          done
+          git commit -am "Bump version"
+          git push
+
       - name: Run chart-releaser library
         uses: helm/chart-releaser-action@v1.6.0
         with:


### PR DESCRIPTION
…or charts

<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
https://parcellab.atlassian.net/browse/INF-1799

Adding extra step in release pipeline to bump the versions for charts before creating the releases.
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
<!--- Include details of how you tested the change -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
