### PR TITLE
feat: INF-1799 adding extra step to run release job only when charts change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,12 +60,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check changed files
+        id: check_files
+        run: |
+          changed_files=$(git diff --name-only HEAD^ HEAD)
+          if echo "${changed_files}" | grep -qE '^parcellab/'; then
+            echo "::set-output name=skip::false"
+          else
+            echo "::set-output name=skip::true"
+          fi
+
       - name: Configure Git
+        if: steps.check_files.outputs.skip == 'false'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Bump version
+        if: steps.check_files.outputs.skip == 'false'
         run: |
           find parcellab -name Chart.yaml | while read file; do
               echo "Processing $file"
@@ -77,6 +89,7 @@ jobs:
           git push
 
       - name: Run chart-releaser library
+        if: steps.check_files.outputs.skip == 'false'
         uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: parcellab

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,10 +55,17 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PARCELLAB_BOT_APPID }}
+          private-key: ${{ secrets.PARCELLAB_BOT_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check changed files
         id: check_files


### PR DESCRIPTION

<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
https://parcellab.atlassian.net/browse/INF-1799
Adding extra step to run release job only when charts are modified.
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
<!--- Include details of how you tested the change -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
