### PR TITLE
fix: rework argo rollouts template

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.79
+version: 1.0.80
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -14,7 +14,7 @@
 {{- $name := include "common.componentname" $componentValues -}}
 {{- $disableReplicaCount := (ternary $service.disableReplicaCount .Values.disableReplicaCount (hasKey $service "disableReplicaCount")) -}}
 {{- $type := default "service" .type -}}
-{{- $argoRollout := default .Values.argoRollout .argoRollout -}}
+{{- $argoRollout := default .Values.argoRollout $service.argoRollout -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,9 +22,7 @@ metadata:
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
 spec:
-  {{- if not (eq $disableReplicaCount true) }}
-  replicas: {{ if not $argoRollout.enabled }}{{ default .Values.replicaCount $service.replicaCount }}{{ else }}0{{ end }}
-  {{- end }}
+  replicas: {{ if or $argoRollout.enabled $disableReplicaCount }}0{{ else }}{{ default .Values.replicaCount $service.replicaCount }}{{ end }}
   {{- if hasKey $service "strategy" }}
   strategy:
     {{- toYaml $service.strategy | nindent 4 }}

--- a/parcellab/common/templates/_rollout.tpl
+++ b/parcellab/common/templates/_rollout.tpl
@@ -13,11 +13,10 @@
 {{- define "common.argorollout" -}}
 {{- $service := default dict .service -}}
 {{- $componentValues := (merge (deepCopy .) (dict "component" $service.name)) -}}
-{{- $name := default (include "common.fullname" .) .name -}}
+{{- $name := include "common.componentname" $componentValues -}}
 {{- $disableReplicaCount := (ternary $service.disableReplicaCount .Values.disableReplicaCount (hasKey $service "disableReplicaCount")) -}}
 {{- $argoRollout := default .Values.argoRollout .argoRollout -}}
-{{- $type := default "service" .type -}}
-{{- if $argoRollout.enabled }}
+{{- $type := default "service" .type }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -86,24 +85,21 @@ spec:
 
 {{- if and $argoRollout.canary $argoRollout.canaryMetrics }}
 {{- range $argoRollout.canaryMetrics }}
-{{- include "common.analysisTemplate" (dict "name" (printf "%s-canary-analysis" $name) "metrics" .) | nindent 0 }}
+{{- include "common.analysisTemplate" (dict "name" (printf "%s-canary" $name) "metrics" .) | nindent 0 }}
 {{- end }}
 {{- end }}
 
 {{- if and $argoRollout.blueGreen $argoRollout.blueGreenMetricsPrePromotion }}
 {{- range $argoRollout.blueGreenMetricsPrePromotion }}
-{{- include "common.analysisTemplate" (dict "name" (printf "%s-bluegreen-prepromotion-analysis" $name) "metrics" .) | nindent 0 }}
+{{- include "common.analysisTemplate" (dict "name" (printf "%s-bluegreen-prepromotion" $name) "metrics" .) | nindent 0 }}
 {{- end }}
 {{- end }}
 
 {{- if and $argoRollout.blueGreen $argoRollout.blueGreenMetricsPostPromotion }}
 {{- range $argoRollout.blueGreenMetricsPostPromotion }}
-{{- include "common.analysisTemplate" (dict "name" (printf "%s-bluegreen-postpromotion-analysis" $name) "metrics" .) | nindent 0 }}
+{{- include "common.analysisTemplate" (dict "name" (printf "%s-bluegreen-postpromotion" $name) "metrics" .) | nindent 0 }}
 {{- end }}
 {{- end }}
 
-{{- $previewService := mergeOverwrite $service (dict "name" (printf "%s-rollout" $name) ) -}}
-{{- include "common.service" (merge (deepCopy .) (dict "service" $previewService )) }}
 ---
-{{- end }}
 {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.93
+version: 0.0.94
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.87
+version: 0.0.88
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/deployment.yaml
+++ b/parcellab/monolith/templates/deployment.yaml
@@ -1,1 +1,3 @@
+{{- if not .Values.disableDefaultAppDeployment }}
 {{- include "common.deployment" . }}
+{{- end }}

--- a/parcellab/monolith/templates/rollout-service.yaml
+++ b/parcellab/monolith/templates/rollout-service.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.extraServices -}}
 {{- $root := . -}}
 {{- range .Values.extraServices }}
-{{- if .argoRollout -}}
-{{- include "common.argorollout" (merge (deepCopy $root) (dict "argoRollout" .argoRollout "name" .name)) }}
+{{- if .argoRollout.enabled -}}
+{{- include "common.argorollout" (merge (deepCopy $root) (dict "argoRollout" .argoRollout "name" .name "service" . "type" "service")) }}
 {{- end }}
 ---
 {{- end -}}

--- a/parcellab/monolith/templates/rollout.yaml
+++ b/parcellab/monolith/templates/rollout.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.argoRollout.enabled }}
 {{- include "common.argorollout" . }}
+{{- end }}

--- a/parcellab/monolith/templates/service.yaml
+++ b/parcellab/monolith/templates/service.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.extraServices -}}
 {{- $root := . -}}
 {{- range .Values.extraServices }}
-{{- if not .argoRollout.enabled }}
 {{- include "common.service" (merge (deepCopy $root) (dict "service" .)) }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if not .Values.disableDefaultAppDeployment }}

--- a/parcellab/monolith/templates/service.yaml
+++ b/parcellab/monolith/templates/service.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.extraServices -}}
 {{- $root := . -}}
 {{- range .Values.extraServices }}
+{{- if not .argoRollout.enabled }}
 {{- include "common.service" (merge (deepCopy $root) (dict "service" .)) }}
 ---
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if not .Values.disableDefaultAppDeployment }}
 {{- include "common.service" . }}
+{{- end }}

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.90
+version: 0.0.91
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
* set `replicas` on the Deployment to 0 if `disableReplicaCount: true` or `argoRollout.enabled: true`
* remove `-analysis` postfix in the AnalysisTemplate name (redundant)
* remove `-rollout` Service generation (we're using the ones that are already provisioned for Deployment)
* fix Rollout name generation (had no Chart name prefix)
* prevent Deployment, Service and Rollout creation for the root application if `monolith.disableDefaultAppDeployment: true`
