### PR TITLE
fix: add missing argoRollout conditional check

### DIFF
--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.95
+version: 0.0.96
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/templates/rollout.yaml
+++ b/parcellab/microservice/templates/rollout.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.argoRollout }}
 {{- if .Values.argoRollout.enabled }}
 {{- include "common.argorollout" . }}
 {{- end }}

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.13
+version: 0.1.14
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/templates/rollout-service.yaml
+++ b/parcellab/monolith/templates/rollout-service.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.extraServices -}}
 {{- $root := . -}}
 {{- range .Values.extraServices }}
+{{- if .argoRollout }}
 {{- if .argoRollout.enabled -}}
 {{- include "common.argorollout" (merge (deepCopy $root) (dict "argoRollout" .argoRollout "name" .name "service" . "type" "service")) }}
 {{- end }}

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.0.98
+version: 0.0.99
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/templates/rollout.yaml
+++ b/parcellab/worker-group/templates/rollout.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.workers -}}
 {{- $root := . -}}
 {{- range .Values.workers }}
+{{- if .argoRollout }}
 {{- if .argoRollout.enabled -}}
 {{- include "common.argorollout" (merge (deepCopy $root) (dict "argoRollout" .argoRollout "name" .name "service" . "type" "worker")) }}
 {{- end }}


### PR DESCRIPTION
Adding conditional checks for `argoRollout` before `argoRollout.enabled` to fix the following:
```
Error: template: portal/charts/monolith/templates/rollout-service.yaml:4:19: executing "portal/charts/monolith/templates/rollout-service.yaml" at <.argoRollout.enabled>: nil pointer evaluating interface {}.enabled
```