### PR TITLE
fix: inf-2797 argorollout values for ingress template

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.87
+version: 1.0.88
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_ingress.tpl
+++ b/parcellab/common/templates/_ingress.tpl
@@ -11,6 +11,7 @@
 {{- $defaultServicePort := .Values.service.port -}}
 {{- if $ingress.enabled -}}
 {{- $name := include "common.fullname" . }}
+{{- $argoRollout := .Values.argoRollout | default dict -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -56,7 +57,7 @@ spec:
             {{- else }}
             backend:
               service:
-                name: {{ if .Values.argoRollout.enabled }} {{ $name }}-rollout {{ else }} {{ $name }} {{ end }}
+                name: {{ if $argoRollout.enabled }} {{ $name }}-rollout {{ else }} {{ $name }} {{ end }}
                 port:
                   number: {{ $defaultServicePort }}
             {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.0.99
+version: 0.1.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.96
+version: 0.0.97
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.14
+version: 0.1.15
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
__Description:__\
This PR updates the `charts/parcellab/common/templates/_ingress.tpl` Helm template to ensure the Ingress is rendered correctly even when the `argoRollout` parameter is not set in the values file.

__Changes:__

- Introduce a local variable for argoRollout using `{{- $argoRollout := .Values.argoRollout | default dict -}}` to guarantee it is always defined.
- Update all references from `.Values.argoRollout.enabled` to `$argoRollout.enabled`.
- Adjust the backend service name logic to use the local variable, ensuring the correct service name is used whether or not argoRollout is set.

__Motivation:__\
Previously, if `argoRollout` was not defined in the values, the template could fail or generate an incorrect Ingress. This change makes the template robust and consistent with other templates that use local variables for values.

__Testing:__

- Verified that the Ingress is rendered correctly when `argoRollout` is present and enabled.
- Verified that the Ingress is rendered correctly and uses the default service name when `argoRollout` is not present.
