### PR TITLE
fix: inf-2837 fixing bug with securityContext and podSecurityContext

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.90
+version: 1.0.91
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_container.tpl
+++ b/parcellab/common/templates/_container.tpl
@@ -16,7 +16,7 @@
       "commonConfig" "Configmap passed from the parent service to be present in the container as well"
       "externalSecret": "ExternalSecret for the container"
       "commonExternalSecret" "Secret passed from the parent service to be present in the container as well"
-      "podSecurityContext": "As the name tells"
+      "securityContext": "As the name tells"
       "volumes" "list of volumes for the container, dict with name, readonly and mountPath"
       "containerEnv" "Environment variables"
       "datadog" "dict for datadog settings"
@@ -33,7 +33,7 @@
   args:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .podSecurityContext }}
+  {{- with .securityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -23,6 +23,7 @@
 {{- $initContainers := .pod.initContainers -}}
 {{- $datadog := .Values.datadog -}}
 {{- $type := default "service" .type -}}
+{{- $securityContext := .Values.securityContext -}}
 metadata:
   annotations:
     {{- if and $datadog $datadog.enabled }}
@@ -70,7 +71,7 @@ spec:
   {{- if $initContainers }}
   initContainers:
   {{- range $initContainers }}
-    {{- include "common.container" (merge (deepCopy .) (dict "volumes" $podVolumes "containerEnv" $containerEnv "datadog" $datadog "commonExternalSecret" $commonExternalSecret "commonConfig" $commonConfig "commonRefName" $fullname)) | nindent 4 }}
+    {{- include "common.container" (merge (deepCopy .) (dict "volumes" $podVolumes "containerEnv" $containerEnv "datadog" $datadog "commonExternalSecret" $commonExternalSecret "commonConfig" $commonConfig "commonRefName" $fullname "securityContext" $securityContext)) | nindent 4 }}
   {{- end }}
   {{- end }}
   containers:
@@ -185,7 +186,7 @@ spec:
       {{- end }}
   {{- if $extraContainers }}
   {{- range $extraContainers }}
-    {{- include "common.container" (merge (deepCopy .) (dict "volumes" $podVolumes "containerEnv" $containerEnv "datadog" $datadog "commonExternalSecret" $commonExternalSecret "commonConfig" $commonConfig "commonRefName" $fullname)) | nindent 4 }}
+    {{- include "common.container" (merge (deepCopy .) (dict "volumes" $podVolumes "containerEnv" $containerEnv "datadog" $datadog "commonExternalSecret" $commonExternalSecret "commonConfig" $commonConfig "commonRefName" $fullname "securityContext" $securityContext)) | nindent 4 }}
   {{- end }}
   {{- end }}
   {{- if or (eq $type "cronjob") (eq $type "job") }}

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -46,7 +46,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   serviceAccountName: {{ include "common.serviceAccountName" . }}
-  {{- with .Values.securityContext }}
+  {{- with .Values.podSecurityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -75,7 +75,7 @@ spec:
   {{- end }}
   containers:
     - name: {{ $containerName }}
-      {{- with .Values.podSecurityContext }}
+      {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.0.99
+version: 0.1.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.17
+version: 0.1.18
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
[INF-2837]

## Description

### Problem

- Security contexts were incorrectly mapped in `_pod.tpl` template (podSecurityContext applied to containers, securityContext applied to pods)
- Init containers and extra containers were not inheriting security context settings
- This caused ArgoCD sync loops and inconsistent security policies across containers

### Changes

- __Fixed security context mapping__:

  - `podSecurityContext` now correctly applies to `spec.securityContext` (pod level)
  - `securityContext` now correctly applies to `spec.containers[].securityContext` (container level)

- __Added security context propagation__: Init containers and extra containers now inherit security context from values

- __Added reusable security context variable__ for cleaner template code

### Impact

- ✅ Resolves ArgoCD sync loop issues
- ✅ Ensures consistent security policies across all containers (main, init, extra)
- ✅ Follows Kubernetes security best practices
- ✅ Maintains backwards compatibility with existing values.yaml configurations

### Testing

Validated against Kubernetes documentation and ArgoCD deployment patterns.



[INF-2837]: https://parcellab.atlassian.net/browse/INF-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ