### PR TITLE
feat: add deployment annotations

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.0.93
+version: 1.1.0
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -15,14 +15,19 @@
 {{- $disableReplicaCount := (ternary $service.disableReplicaCount .Values.disableReplicaCount (hasKey $service "disableReplicaCount")) -}}
 {{- $type := default "service" .type -}}
 {{- $argoRollout := default .Values.argoRollout $service.argoRollout -}}
+{{- $globalAnnotations := default dict .Values.deploymentAnnotations -}}
+{{- $serviceAnnotations := default dict $service.annotations -}}
+{{- $mergedAnnotations := merge $serviceAnnotations $globalAnnotations -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
+  {{- if $mergedAnnotations }}
   annotations:
-    reloader.stakater.com/auto: "true"
+    {{- toYaml $mergedAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not $disableReplicaCount }}
   replicas: {{ if $argoRollout.enabled }} 0 {{ else }} {{ default .Values.replicaCount $service.replicaCount }} {{ end }}

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -16,7 +16,7 @@
 {{- $type := default "service" .type -}}
 {{- $argoRollout := default .Values.argoRollout $service.argoRollout -}}
 {{- $globalAnnotations := default dict .Values.deploymentAnnotations -}}
-{{- $serviceAnnotations := default dict $service.annotations -}}
+{{- $serviceAnnotations := default dict $service.deploymentAnnotations -}}
 {{- $mergedAnnotations := merge $serviceAnnotations $globalAnnotations -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/parcellab/common/templates/_deployment.tpl
+++ b/parcellab/common/templates/_deployment.tpl
@@ -21,6 +21,8 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "common.labels" $componentValues | nindent 4 }}
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   {{- if not $disableReplicaCount }}
   replicas: {{ if $argoRollout.enabled }} 0 {{ else }} {{ default .Values.replicaCount $service.replicaCount }} {{ end }}

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -8,6 +8,9 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
 config: {}
 containerEnv: {}
+# Global deployment annotations that will be applied to all deployments
+# These can be overridden by service-specific annotations
+deploymentAnnotations: {}
 argoRollout:
   enabled: false
 datadog:

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.1.4
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.1.1
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.20
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.1.6
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
Global annotations for the deployments can now be defined with `.Values.deploymentAnnotations`, and/or on a service level with `$service.deploymentAnnotations`. If both are defined - they will be merged, which means if the service annotation has the same key - it'll overwrite the one from the root level.