### PR TITLE
feat: INF-2896 allow containerEnv to use map format aside from list

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_container.tpl
+++ b/parcellab/common/templates/_container.tpl
@@ -1,5 +1,68 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+  Helper function to merge containerEnv from multiple sources:
+  {{ include "common.mergeContainerEnv" (dict "global" .Values.containerEnv "local" .pod.containerEnv) }}
+*/}}
+{{- define "common.mergeContainerEnv" -}}
+{{- $envMap := dict -}}
+{{- $globalEnv := .global | default dict -}}
+{{- $localEnv := .local | default dict -}}
+
+{{- /* Convert global containerEnv to map for deduplication */ -}}
+{{- if $globalEnv -}}
+{{- if kindIs "slice" $globalEnv -}}
+{{- range $globalEnv -}}
+{{- $envMap = set $envMap .name . -}}
+{{- end -}}
+{{- else if kindIs "map" $globalEnv -}}
+{{- range $key, $value := $globalEnv -}}
+{{- $envMap = set $envMap $key (dict "name" $key "value" ($value | toString)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Convert local containerEnv to map and override global values */ -}}
+{{- if $localEnv -}}
+{{- if kindIs "slice" $localEnv -}}
+{{- range $localEnv -}}
+{{- $envMap = set $envMap .name . -}}
+{{- end -}}
+{{- else if kindIs "map" $localEnv -}}
+{{- range $key, $value := $localEnv -}}
+{{- $envMap = set $envMap $key (dict "name" $key "value" ($value | toString)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Convert back to list and output */ -}}
+{{- if $envMap -}}
+{{- $merged := list -}}
+{{- range $name, $envVar := $envMap -}}
+{{- $merged = append $merged $envVar -}}
+{{- end -}}
+{{- toYaml $merged | trimSuffix "\n" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Helper function to handle containerEnv in both object and array formats:
+  {{ include "common.containerEnvVariables" .containerEnv }}
+*/}}
+{{- define "common.containerEnvVariables" -}}
+{{- if kindIs "slice" . -}}
+{{- /* Array format - use as-is */ -}}
+{{- toYaml . | trimSuffix "\n" -}}
+{{- else if kindIs "map" . -}}
+{{- /* Object format - convert to array */ -}}
+{{- $items := list -}}
+{{- range $key, $value := . -}}
+{{- $items = append $items (dict "name" $key "value" ($value | toString)) -}}
+{{- end -}}
+{{- toYaml $items | trimSuffix "\n" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   Keys and quoted values generated from a given dict:
   {{ include "common.container" (
     dict
@@ -18,7 +81,7 @@
       "commonExternalSecret" "Secret passed from the parent service to be present in the container as well"
       "securityContext": "As the name tells"
       "volumes" "list of volumes for the container, dict with name, readonly and mountPath"
-      "containerEnv" "Environment variables"
+      "containerEnv" "Environment variables (supports both object and array formats)"
       "datadog" "dict for datadog settings"
       "commonRefName" "Name of the parent service to be included as prefix in the resource names for transparency"
   ) }}
@@ -79,8 +142,12 @@
     {{- end }}
   env:
     {{- include "common.datadogEnvironmentVariables" (dict "datadog" .datadog) | nindent 4 }}
-    {{- with .containerEnv }}
-    {{- toYaml . | nindent 4 }}
+    {{- if .containerEnv }}
+    {{- if kindIs "string" .containerEnv }}
+    {{- .containerEnv | nindent 4 }}
+    {{- else }}
+    {{- include "common.containerEnvVariables" .containerEnv | nindent 4 }}
+    {{- end }}
     {{- end }}
   {{- if or .commonConfig .config .commonExternalSecret .externalSecret }}
   envFrom:

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -15,7 +15,7 @@
 {{- $containerName := default $name .pod.containerName -}}
 {{- $defaultImageValues := dict "repository" (include "common.imagerepository" $root) "tag" (include "common.version" $root) -}}
 {{- $containerImage := merge (dict "image" .pod.image) (dict "image" $defaultImageValues) -}}
-{{- $containerEnv := default .Values.containerEnv .pod.containerEnv -}}
+{{- $containerEnv := include "common.mergeContainerEnv" (dict "global" .Values.containerEnv "local" .pod.containerEnv) -}}
 {{- $podVolumes := default .Values.volumes .pod.volumes -}}
 {{- $commonExternalSecret := .Values.externalSecret -}}
 {{- $commonConfig := .Values.config -}}
@@ -158,8 +158,8 @@ spec:
         {{- end }}
       env:
         {{- include "common.datadogEnvironmentVariables" (dict "datadog" $datadog) | nindent 8 }}
-        {{- with $containerEnv }}
-        {{- toYaml . | nindent 8 }}
+        {{- if $containerEnv }}
+        {{- $containerEnv | nindent 8 }}
         {{- end }}
       {{- if or .Values.config .pod.configName .Values.externalSecret .pod.secretName }}
       envFrom:

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
`containerEnv` can now be used in the following format:
```env_name: env_value```

It can be specified on multiple levels, such as:
* root (`.Values.containerEnv`)
* extra services (`extraServices[0].containerEnv`)
* common worker config (`worker.containerEnv`)
* workers (`workers[0].containerEnv`)

If envs are defined on multiple levels - they'll be merged together. If env with the same key is defined on multiple levels, it's value from the lower (more specific) level will take precedence. E.g. in case of `root` and `workers` level - workers level value will overwrite the root one.


Tested locally with onyx helm chart - works as described above.