### PR TITLE
feat: update chart dependencies to use bitnamilegacy repository

### DIFF
--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.1.4
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 15.5.38
+    version: 17.0.0
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 21.1.5
+    version: 23.0.2
     condition: redis.enabled

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -126,7 +126,7 @@ resources:
 postgresql:
   enabled: false
   security:
-    allowInsecureImages: false
+    allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0
@@ -139,7 +139,7 @@ postgresql:
 redis:
   enabled: false
   security:
-    allowInsecureImages: false
+    allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
     tag: 8.2.1

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -125,8 +125,9 @@ resources:
 
 postgresql:
   enabled: false
-  security:
-    allowInsecureImages: true
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0
@@ -138,8 +139,9 @@ postgresql:
 
 redis:
   enabled: false
-  security:
-    allowInsecureImages: true
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
     tag: 8.2.1

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -126,6 +126,11 @@ resources:
 
 postgresql:
   enabled: false
+  security:
+    allowInsecureImages: false
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 17.4.0
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
 
 ##
@@ -134,4 +139,9 @@ postgresql:
 
 redis:
   enabled: false
+  security:
+    allowInsecureImages: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: 8.2.1
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.1.1
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 15.5.38
+    version: 17.0.0
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 21.1.5
+    version: 23.0.2
     condition: redis.enabled

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -287,8 +287,7 @@ resources:
 postgresql:
   enabled: false
   security:
-    allowInsecureImages: false
-
+    allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0
@@ -302,7 +301,7 @@ redis:
   enabled: false
   global:
     security:
-      allowInsecureImages: false
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
     tag: 8.2.1

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -286,8 +286,9 @@ resources:
 
 postgresql:
   enabled: false
-  security:
-    allowInsecureImages: true
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -287,6 +287,12 @@ resources:
 
 postgresql:
   enabled: false
+  security:
+    allowInsecureImages: false
+
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 17.4.0
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
 
 ##
@@ -295,6 +301,12 @@ postgresql:
 
 redis:
   enabled: false
+  global:
+    security:
+      allowInsecureImages: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: 8.2.1
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
 
 #  these containers share secrets, configmaps, volumes and environment variables from the settings above

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,18 +1,18 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.1.19
+version: 0.2.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 15.5.38
+    version: 17.0.0
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 21.1.5
+    version: 23.0.2
     condition: redis.enabled
   - name: mongodb
     version: 16.5.11

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -422,8 +422,9 @@ resources:
 
 postgresql:
   enabled: false
-  security:
-    allowInsecureImages: true
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -423,8 +423,7 @@ resources:
 postgresql:
   enabled: false
   security:
-    allowInsecureImages: false
-
+    allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
     tag: 17.4.0
@@ -439,7 +438,7 @@ redis:
   enabled: false
   global:
     security:
-      allowInsecureImages: false
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
     tag: 8.2.1
@@ -459,7 +458,7 @@ mongodb:
   enabled: false
   global:
     security:
-      allowInsecureImages: false
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/mongodb
     tag: 8.0.13-debian-12-r0

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -423,6 +423,12 @@ resources:
 
 postgresql:
   enabled: false
+  security:
+    allowInsecureImages: false
+
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 17.4.0
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
   primary:
     persistentVolumeClaimRetentionPolicy:
@@ -432,6 +438,12 @@ postgresql:
 
 redis:
   enabled: false
+  global:
+    security:
+      allowInsecureImages: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: 8.2.1
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
   master:
     persistentVolumeClaimRetentionPolicy:
@@ -446,6 +458,12 @@ redis:
 
 mongodb:
   enabled: false
+  global:
+    security:
+      allowInsecureImages: false
+  image:
+    repository: bitnamilegacy/mongodb
+    tag: 8.0.13-debian-12-r0
   # See default values: https://artifacthub.io/packages/helm/bitnami/mongodb?modal=values
   persistentVolumeClaimRetentionPolicy:
     enabled: true


### PR DESCRIPTION
The bitnami migration towards bitnamilegacy requires the use of the bitnamilegacy repository in our dependencies