### PR TITLE
feat: enable deploymentAnnotations in monolith

### DIFF
--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -462,6 +462,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+deploymentAnnotations: {}
+
 replicaCount: 1
 # disables setting replica count in case of autoscaling enabled
 disableReplicaCount: false


### PR DESCRIPTION
Need this to be able to specify `reloader.stakater.com/auto: "true"` globally