### PR TITLE
feat: make OIDC passThroughAuthHeader and refreshToken configurable

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.3.6
+version: 1.3.7
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_securitypolicies.tpl
+++ b/parcellab/common/templates/_securitypolicies.tpl
@@ -44,7 +44,7 @@
 {{- $jwksURI := coalesce $policy.jwksURI $globalJwksURI (printf "%s/protocol/openid-connect/certs" $issuer) -}}
 {{- $backendRefs := coalesce $policy.backendRefs $security.backendRefs -}}
 {{- $annotations := merge (default (dict) $policy.annotations) $globalAnnotations -}}
-{{- $passThroughAuthHeader := false -}}
+{{- $passThroughAuthHeader := true -}}
 {{- if hasKey $policy "passThroughAuthHeader" -}}
   {{- $passThroughAuthHeader = $policy.passThroughAuthHeader -}}
 {{- else if hasKey $security "passThroughAuthHeader" -}}

--- a/parcellab/common/templates/_securitypolicies.tpl
+++ b/parcellab/common/templates/_securitypolicies.tpl
@@ -26,6 +26,8 @@
 {{- $globalJwtProviderName := $security.jwtProviderName -}}
 {{- $globalJwksURI := $security.jwksURI -}}
 {{- $globalAnnotations := default (dict) $security.annotations -}}
+{{- $globalPassThroughAuthHeader := $security.passThroughAuthHeader -}}
+{{- $globalRefreshToken := $security.refreshToken -}}
 
 {{ range $policyIndex, $policy := $policies }}
 {{- $policyName := required (printf "envoy.security.policies[%d].name is required" $policyIndex) $policy.name -}}
@@ -42,6 +44,18 @@
 {{- $jwksURI := coalesce $policy.jwksURI $globalJwksURI (printf "%s/protocol/openid-connect/certs" $issuer) -}}
 {{- $backendRefs := coalesce $policy.backendRefs $security.backendRefs -}}
 {{- $annotations := merge (default (dict) $policy.annotations) $globalAnnotations -}}
+{{- $passThroughAuthHeader := false -}}
+{{- if hasKey $policy "passThroughAuthHeader" -}}
+  {{- $passThroughAuthHeader = $policy.passThroughAuthHeader -}}
+{{- else if hasKey $security "passThroughAuthHeader" -}}
+  {{- $passThroughAuthHeader = $globalPassThroughAuthHeader -}}
+{{- end -}}
+{{- $refreshToken := true -}}
+{{- if hasKey $policy "refreshToken" -}}
+  {{- $refreshToken = $policy.refreshToken -}}
+{{- else if hasKey $security "refreshToken" -}}
+  {{- $refreshToken = $globalRefreshToken -}}
+{{- end -}}
 {{- $targetRef := $policy.targetRef -}}
 {{- $targetRefs := $policy.targetRefs -}}
 {{- $rawSelectors := list -}}
@@ -104,7 +118,8 @@ spec:
     {{- end }}
     cookieDomain: {{ $cookieDomain | quote }}
     forwardAccessToken: true
-    passThroughAuthHeader: true
+    passThroughAuthHeader: {{ $passThroughAuthHeader }}
+    refreshToken: {{ $refreshToken }}
   jwt:
     optional: false
     providers:

--- a/parcellab/common/templates/_securitypolicies.tpl
+++ b/parcellab/common/templates/_securitypolicies.tpl
@@ -45,15 +45,15 @@
 {{- $backendRefs := coalesce $policy.backendRefs $security.backendRefs -}}
 {{- $annotations := merge (default (dict) $policy.annotations) $globalAnnotations -}}
 {{- $passThroughAuthHeader := true -}}
-{{- if hasKey $policy "passThroughAuthHeader" -}}
+{{- if and (hasKey $policy "passThroughAuthHeader") (ne $policy.passThroughAuthHeader nil) -}}
   {{- $passThroughAuthHeader = $policy.passThroughAuthHeader -}}
-{{- else if hasKey $security "passThroughAuthHeader" -}}
+{{- else if and (hasKey $security "passThroughAuthHeader") (ne $globalPassThroughAuthHeader nil) -}}
   {{- $passThroughAuthHeader = $globalPassThroughAuthHeader -}}
 {{- end -}}
 {{- $refreshToken := true -}}
-{{- if hasKey $policy "refreshToken" -}}
+{{- if and (hasKey $policy "refreshToken") (ne $policy.refreshToken nil) -}}
   {{- $refreshToken = $policy.refreshToken -}}
-{{- else if hasKey $security "refreshToken" -}}
+{{- else if and (hasKey $security "refreshToken") (ne $globalRefreshToken nil) -}}
   {{- $refreshToken = $globalRefreshToken -}}
 {{- end -}}
 {{- $targetRef := $policy.targetRef -}}

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.5.6
+version: 0.5.7
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -116,6 +116,8 @@ envoy:
     # redirectURL: "https://my-app.example.com/oauth2/callback"
     # cookieDomain: "my-app.example.com"
     # annotations: {}          # optional: annotations applied to all SecurityPolicy resources
+    # passThroughAuthHeader: true   # optional: default true. Set false to reject unauthenticated requests at the gateway instead of forwarding the incoming Authorization header to the backend.
+    # refreshToken: true            # optional: default true. Keep the OIDC session alive via refresh tokens.
     # scopes:
     #   - profile
     #   - email

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.5.7
+version: 0.5.8
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -145,6 +145,8 @@ envoy:
     # redirectURL: "https://my-app.example.com/oauth2/callback"
     # cookieDomain: "my-app.example.com"
     # annotations: {}          # optional: annotations applied to all SecurityPolicy resources
+    # passThroughAuthHeader: true   # optional: default true. Set false to reject unauthenticated requests at the gateway instead of forwarding the incoming Authorization header to the backend.
+    # refreshToken: true            # optional: default true. Keep the OIDC session alive via refresh tokens.
     # scopes:
     #   - profile
     #   - email


### PR DESCRIPTION
## Summary
- Expose `envoy.security.passThroughAuthHeader` and `envoy.security.refreshToken` (also per-policy via `envoy.security.policies[].*`) in the common `SecurityPolicy` template so services can match the proven graylog OIDC setup.
- Defaults stay at `passThroughAuthHeader: true` / `refreshToken: true` to preserve prior behavior. Services hitting "JWT is missing" (e.g. arena) can opt into `passThroughAuthHeader: false` so unauthenticated requests are rejected at the gateway instead of forwarded.
- Bumps: `common 1.3.6 → 1.3.7`, `microservice 0.5.6 → 0.5.7`, `monolith 0.5.7 → 0.5.8`.

## Test plan
- [x] `helm lint parcellab/microservice` passes
- [x] `helm template` with default values renders `passThroughAuthHeader: true` and `refreshToken: true`
- [x] `helm template` with explicit overrides renders the supplied values
- [ ] Deploy arena (PR parcelLab/arena#18) with `microservice 0.5.7` + `passThroughAuthHeader: false` and confirm OIDC login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)