### PR TITLE
chore: update checkout action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       charts: ${{ steps.generate-matrix.outputs.charts }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load repos configuration file
         id: generate-matrix
@@ -32,7 +32,7 @@ jobs:
         chart: ${{ fromJSON(needs.matrix.outputs.charts) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update dependencies
         run: helm dependency update ${{ matrix.chart }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.3.8
+version: 1.3.9
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com


### PR DESCRIPTION
use latest checkout GitHub action und bump common version because of https://github.com/parcelLab/charts/actions/runs/26120763951/job/76821965626