### PR TITLE
feat: add podLabels to pod template

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.3.9
+version: 1.3.10
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -38,14 +38,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "common.labels" $componentValues | nindent 4 }}
+    {{- /* Merge into one dict so user podLabels can't duplicate keys or override
+           the managed selector labels (which would break the Deployment selector). */}}
+    {{- $managed := include "common.labels" $componentValues | fromYaml }}
     {{- if and $datadog $datadog.enabled }}
-    tags.datadoghq.com/env: {{ include "common.env" . | quote }}
-    tags.datadoghq.com/service: {{ $fullname | quote }}
+    {{- $_ := set $managed "tags.datadoghq.com/env" (include "common.env" . | trim) }}
+    {{- $_ := set $managed "tags.datadoghq.com/service" $fullname }}
     {{- end }}
-    {{- with .Values.podLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml (merge $managed (.Values.podLabels | default dict)) | nindent 4 }}
 spec:
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -43,6 +43,9 @@ metadata:
     tags.datadoghq.com/env: {{ include "common.env" . | quote }}
     tags.datadoghq.com/service: {{ $fullname | quote }}
     {{- end }}
+    {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:

--- a/parcellab/common/values.yaml
+++ b/parcellab/common/values.yaml
@@ -36,6 +36,9 @@ terminationGracePeriodSeconds: 30
 nodeSelector: {}
 orgRepository: ghcr.io/parcellab
 podAnnotations: {}
+# Extra labels added to the pod template only (merged so they can never override
+# the managed selector labels). E.g. { parcellab.dev/compute: fargate }.
+podLabels: {}
 podDisruptionBudget:
   enabled: false
 podSecurityContext: {}

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.5.1
+version: 0.5.2
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -78,6 +78,11 @@ nodeSelector: {}
 
 podAnnotations: {}
 
+# Extra labels added to the pod template only (not the selector, which stays
+# immutable). Useful for scheduling controls that key off pod labels, e.g.
+# opting into an EKS Fargate profile: { parcellab.dev/compute: fargate }.
+podLabels: {}
+
 securityContext:
   {}
   # capabilities:

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.5.8
+version: 0.5.9
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -363,6 +363,11 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Extra labels added to the pod template only (not the selector, which stays
+# immutable). Useful for scheduling controls that key off pod labels, e.g.
+# opting into an EKS Fargate profile: { parcellab.dev/compute: fargate }.
+podLabels: {}
+
 replicaCount: 1
 
 strategy:

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.5.9
+version: 0.5.10
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -512,6 +512,11 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Extra labels added to the pod template only (not the selector, which stays
+# immutable). Useful for scheduling controls that key off pod labels, e.g.
+# opting into an EKS Fargate profile: { parcellab.dev/compute: fargate }.
+podLabels: {}
+
 deploymentAnnotations: {}
 
 replicaCount: 1

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.3.4
+version: 0.3.5
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/values.yaml
+++ b/parcellab/worker-group/values.yaml
@@ -166,6 +166,11 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Extra labels added to the pod template only (not the selector, which stays
+# immutable). Useful for scheduling controls that key off pod labels, e.g.
+# opting into an EKS Fargate profile: { parcellab.dev/compute: fargate }.
+podLabels: {}
+
 replicaCount: 1
 disableReplicaCount: false
 


### PR DESCRIPTION
Adds an optional `podLabels` value to the shared `common` pod template, merged into the **pod template labels only** — the (immutable) Deployment/Rollout selector is untouched, and managed/selector labels always win on collision (user labels can only add new keys).

Enables scheduling controls that key off pod labels without per-app template hacks. First consumer: opting a workload into the EKS **Fargate isolated tier** (per-pod Firecracker microVMs) via `podLabels: { parcellab.dev/compute: fargate }`, which an EKS Fargate profile selects.

## Changes

- `common/_pod.tpl`: merge `.Values.podLabels` into pod template `metadata.labels` via a single dict merge (managed labels take precedence — no duplicate keys, selector can't be broken)
- `common/values.yaml` + `microservice/values.yaml`: document `podLabels: {}`
- version bumps so chart-releaser republishes **every** consumer with the new `common` (the feature lives in `common`, so it applies to all chart types — not just microservice):
  - `common` 1.3.9 → 1.3.10
  - `microservice` 0.5.8 → 0.5.9
  - `cronjob` 0.5.1 → 0.5.2
  - `monolith` 0.5.9 → 0.5.10
  - `worker-group` 0.3.4 → 0.3.5
