### PR TITLE
chore: clean up DB subcharts

### DIFF
--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,16 +1,8 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.5.2
+version: 0.6.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.7.27
-    condition: postgresql.enabled
-  - name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 22.0.7
-    condition: redis.enabled

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -134,31 +134,3 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
-
-##
-## Postgresql
-##
-
-postgresql:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: postgres
-    tag: 17-alpine
-  # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
-
-##
-## Redis
-##
-
-redis:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: redis
-    tag: 8-alpine
-  # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values

--- a/parcellab/cronjob/values.yaml
+++ b/parcellab/cronjob/values.yaml
@@ -145,8 +145,8 @@ postgresql:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/postgresql
-    tag: 17.4.0
+    repository: postgres
+    tag: 17-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
 
 ##
@@ -159,6 +159,6 @@ redis:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/redis
-    tag: 8.2.1
+    repository: redis
+    tag: 8-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,16 +1,8 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.5.9
+version: 0.6.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.7.27
-    condition: postgresql.enabled
-  - name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 22.0.7
-    condition: redis.enabled

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -441,16 +441,6 @@ resources:
 ## Redis
 ##
 
-redis:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: redis
-    tag: 8-alpine
-  # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
-
 #  these containers share secrets, configmaps, volumes and environment variables from the settings above
 initContainers: []
 #  - name: myInitContainer1

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -447,8 +447,8 @@ postgresql:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/postgresql
-    tag: 17.4.0
+    repository: postgres
+    tag: 17-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
 
 ##
@@ -461,8 +461,8 @@ redis:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/redis
-    tag: 8.2.1
+    repository: redis
+    tag: 8-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
 
 #  these containers share secrets, configmaps, volumes and environment variables from the settings above

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -438,20 +438,6 @@ resources:
 #     port: http
 
 ##
-## Postgresql
-##
-
-postgresql:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: postgres
-    tag: 17-alpine
-  # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
-
-##
 ## Redis
 ##
 

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,20 +1,12 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.5.10
+version: 0.6.0
 dependencies:
   - name: common
     version: "*"
     repository: file://../common
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.7.27
-    condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 22.0.7
     condition: redis.enabled
-  - name: mongodb
-    version: 16.5.11
-    repository: https://charts.bitnami.com/bitnami
-    condition: mongodb.enabled

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -587,7 +587,7 @@ redis:
       allowInsecureImages: true
   image:
     repository: redis
-    tag: 8-alpine
+    tag: 8
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
   master:
     persistentVolumeClaimRetentionPolicy:

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -580,21 +580,6 @@ resources:
 #       - "foo.local"
 #       - "bar.local"
 
-postgresql:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: postgres
-    tag: 17-alpine
-  # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
-  primary:
-    persistentVolumeClaimRetentionPolicy:
-      enabled: true
-      whenDeleted: Delete
-      whenScaled: Delete
-
 redis:
   enabled: false
   global:
@@ -614,17 +599,3 @@ redis:
       enabled: true
       whenDeleted: Delete
       whenScaled: Delete
-
-mongodb:
-  enabled: false
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: mongo
-    tag: 8
-  # See default values: https://artifacthub.io/packages/helm/bitnami/mongodb?modal=values
-  persistentVolumeClaimRetentionPolicy:
-    enabled: true
-    whenDeleted: Delete
-    whenScaled: Delete

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -586,8 +586,8 @@ postgresql:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/postgresql
-    tag: 17.4.0
+    repository: postgres
+    tag: 17-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values
   primary:
     persistentVolumeClaimRetentionPolicy:
@@ -601,8 +601,8 @@ redis:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/redis
-    tag: 8.2.1
+    repository: redis
+    tag: 8-alpine
   # See default values: https://artifacthub.io/packages/helm/bitnami/redis?modal=values
   master:
     persistentVolumeClaimRetentionPolicy:
@@ -621,8 +621,8 @@ mongodb:
     security:
       allowInsecureImages: true
   image:
-    repository: bitnamilegacy/mongodb
-    tag: 8.0.13-debian-12-r0
+    repository: mongo
+    tag: 8
   # See default values: https://artifacthub.io/packages/helm/bitnami/mongodb?modal=values
   persistentVolumeClaimRetentionPolicy:
     enabled: true


### PR DESCRIPTION
1. Remove postgresql and mongodb subcharts for all parcellab charts
2. Remove redis subchart from all but `monolith` - it's still used in `product-api-preview`
3. Migrate redis subchart image for monolith from `bitnamilegacy/redis` to official `redis`