### PR TITLE
feat(httproutes): support per-route annotations in httpRoutes

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.3.10
+version: 1.3.11
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_httproutes.tpl
+++ b/parcellab/common/templates/_httproutes.tpl
@@ -75,6 +75,9 @@ metadata:
     {{- end }}
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "{{ join "," $route.hosts }}"
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   parentRefs:
     - name: {{ $gateway.name }}

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.6.0
+version: 0.6.1
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/values.yaml
+++ b/parcellab/microservice/values.yaml
@@ -111,6 +111,8 @@ envoy:
   #       #     requestTimeout: 30s
   #     labels:
   #       foo: bar # optional
+  #     annotations:
+  #       foo: bar # optional
   grpcRoutes: []
   #   - name: my-default-grpc-route
   #     hosts:

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.6.0
+version: 0.6.1
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -174,7 +174,7 @@ envoy:
   #     labels:
   #       foo: bar # optional
   #     annotations:
-  #       some-annotation-key: some-annotation-value # optional: extra annotations applied to this GRPCRoute resource
+  #       foo: bar # optional: extra annotations applied to this GRPCRoute resource
   security:
     enabled: false
     # enabled: true

--- a/parcellab/monolith/values.yaml
+++ b/parcellab/monolith/values.yaml
@@ -140,6 +140,8 @@ envoy:
   #       #     requestTimeout: 30s
   #     labels:
   #       foo: bar # optional
+  #     annotations:
+  #       foo: bar # optional
   grpcRoutes: []
   #   - name: my-default-grpc-route
   #     hosts:
@@ -171,6 +173,8 @@ envoy:
   #       #     requestTimeout: 30s
   #     labels:
   #       foo: bar # optional
+  #     annotations:
+  #       some-annotation-key: some-annotation-value # optional: extra annotations applied to this GRPCRoute resource
   security:
     enabled: false
     # enabled: true


### PR DESCRIPTION
Allow consumers to set arbitrary annotations on individual HTTPRoute resources via the httpRoutes[].annotations field in values. Previously only the external-dns annotation was emitted; all other per-route annotations were silently ignored.

[INF-4027]


[INF-4027]: https://parcellab.atlassian.net/browse/INF-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ