### PR TITLE
fix: include Datadog version label on pod workloads

### DIFF
--- a/parcellab/common/Chart.yaml
+++ b/parcellab/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A Helm chart library for parcelLab charts
 type: library
-version: 1.3.11
+version: 1.3.12
 maintainers:
   - name: parcelLab
     email: engineering@parcellab.com

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -44,6 +44,7 @@ metadata:
     {{- if and $datadog $datadog.enabled }}
     {{- $_ := set $managed "tags.datadoghq.com/env" (include "common.env" . | trim) }}
     {{- $_ := set $managed "tags.datadoghq.com/service" $fullname }}
+    {{- $_ := set $managed "tags.datadoghq.com/version" $containerImage.image.tag }}
     {{- end }}
     {{- toYaml (merge $managed (.Values.podLabels | default dict)) | nindent 4 }}
 spec:

--- a/parcellab/common/templates/_pod.tpl
+++ b/parcellab/common/templates/_pod.tpl
@@ -44,7 +44,7 @@ metadata:
     {{- if and $datadog $datadog.enabled }}
     {{- $_ := set $managed "tags.datadoghq.com/env" (include "common.env" . | trim) }}
     {{- $_ := set $managed "tags.datadoghq.com/service" $fullname }}
-    {{- $_ := set $managed "tags.datadoghq.com/version" $containerImage.image.tag }}
+    {{- $_ := set $managed "tags.datadoghq.com/version" ($containerImage.image.tag | trunc 63 | trimAll "._-") }}
     {{- end }}
     {{- toYaml (merge $managed (.Values.podLabels | default dict)) | nindent 4 }}
 spec:

--- a/parcellab/cronjob/Chart.yaml
+++ b/parcellab/cronjob/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronjob
 description: Single cron job
-version: 0.6.0
+version: 0.6.1
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/microservice/Chart.yaml
+++ b/parcellab/microservice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: microservice
 description: Simple microservice
-version: 0.6.1
+version: 0.6.2
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/monolith/Chart.yaml
+++ b/parcellab/monolith/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Application that may define multiple services and cronjobs
-version: 0.6.1
+version: 0.6.2
 dependencies:
   - name: common
     version: "*"

--- a/parcellab/worker-group/Chart.yaml
+++ b/parcellab/worker-group/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: worker-group
 description: Set of workers that do not expose a service
-version: 0.3.5
+version: 0.3.6
 dependencies:
   - name: common
     version: "*"


### PR DESCRIPTION
Why: Applications derive `DD_VERSION` from the `tags.datadoghq.com/version` pod label, but the shared chart never rendered that label. Product API therefore reports Sentry events without a release even though deployments use a release-specific image tag.

Use each workload’s resolved container image tag so service, worker, and cron pods expose the same deployed version. Consumer chart patch versions are bumped so the updated common library can be published through each chart.

Validated with `npm test`, an explicit service/worker/cron render using `image.tag=release-sha`, scoped Prettier, and `git diff --check`.